### PR TITLE
Fix XPC connection invalid error after bluetooth turned off and on

### DIFF
--- a/Desk Controller/BluetoothManager.swift
+++ b/Desk Controller/BluetoothManager.swift
@@ -48,8 +48,10 @@ class BluetoothManager: NSObject {
     }
     
     func startScanning() {
-        let queue = DispatchQueue(label: "BT_queue")
-        centralManager = CBCentralManager(delegate: self, queue: queue)
+        if (centralManager == nil) {
+            let queue = DispatchQueue(label: "BT_queue")
+            centralManager = CBCentralManager(delegate: self, queue: queue)
+        }
     }
     
     func reconnect() {


### PR DESCRIPTION
Based on what I found on the errror message, this happens when a CBCentralManager instance is disposed. As `startScanning` is invoked every time the user opens up the popup UI a new instance was created each time. By adding this extra check to only reinitialize when the instance is nil I managed to fix the issue  #10. 

I'm not sure if there is any other conditions that would need for a reinitialisation of the CBCentralManager but couldn't reproduce any issues with this fix yet.