### PR TITLE
Changed the bluetooth filter to allow more linak models to be discovered

### DIFF
--- a/Desk Controller/BluetoothManager.swift
+++ b/Desk Controller/BluetoothManager.swift
@@ -35,7 +35,7 @@ class BluetoothManager: NSObject {
     
     // It will only match if the Name contains 'Desk' in it
     var matchCriteria: (CBPeripheral) -> Bool = { peripheral in
-        guard let name = peripheral.name, name.contains("Desk") else {
+        guard let name = peripheral.name, name.lowercased().contains("desk") else {
             return false
         }
         return true


### PR DESCRIPTION
Got a new desk  with a Linak dpg1c controller, I saw your all and it wasn't able to identify my desk, the name of the des has DESK written all in caps.
After changing the bluetooth filter, the desk works flawlessly with the app.

Don't know if you want to have this just for the idasen, if so, feel free to close and disregard this PR.

