### PR TITLE
Double tap desk handle to sit/stand

### DIFF
--- a/Desk Controller/AutoStand.swift
+++ b/Desk Controller/AutoStand.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Quartz
 
 class AutoStand: NSObject {
     

--- a/Desk Controller/Desk control/DeskController.swift
+++ b/Desk Controller/Desk control/DeskController.swift
@@ -21,7 +21,12 @@ class DeskController: NSObject {
             onCurrentMovingDirectionChange(currentMovingDirection)
         }
     }
-    
+
+    var onDoubleTapDetected: ((_ direction: MovingDirection) -> ())? {
+        didSet {
+            self.desk.onDoubleTapDetected = onDoubleTapDetected
+        }
+    }
 
     var movingToPosition: Position? = nil {
         didSet {

--- a/Desk Controller/Desk control/DeskPeripheral.swift
+++ b/Desk Controller/Desk control/DeskPeripheral.swift
@@ -136,22 +136,25 @@ extension DeskPeripheral: CBPeripheralDelegate {
             speed = Float(speedValue)
             position = Float(positionValue) / 100 + DeskPeripheral.heightPositionOffset
 
-            var switchAction: SwitchControlCommand.SwitchAction = .neutral
-
-            switch speed {
-                case _ where speed == 0:
-                    switchAction = .neutral
-                case _ where speed < 0:
-                    switchAction = .down
-                case _ where speed > 0:
-                    switchAction = .up
-                default:
-                    break
-            }
-
-            let switchControlCommand = SwitchControlCommand(switchAction: switchAction, time: Date())
-            self.lastSwitchControlCommand = SwitchControlCommand(switchAction: switchAction, time: Date())
+            self.detectSwitchAction(speed: speed)
         }
+    }
+
+    private func detectSwitchAction(speed: Float) {
+        var switchAction: SwitchControlCommand.SwitchAction = .neutral
+
+        switch speed {
+            case _ where speed == 0:
+                switchAction = .neutral
+            case _ where speed < 0:
+                switchAction = .down
+            case _ where speed > 0:
+                switchAction = .up
+            default:
+                break
+        }
+
+        self.lastSwitchControlCommand = SwitchControlCommand(switchAction: switchAction, time: Date())
     }
 }
 

--- a/Desk Controller/Desk control/DeskPeripheral.swift
+++ b/Desk Controller/Desk control/DeskPeripheral.swift
@@ -12,57 +12,72 @@ class DeskPeripheral: NSObject {
 
     public static let deskPositionServiceUUID = CBUUID.init(string: "99FA0020-338A-1024-8A49-009C0215F78A")
     public static let deskPositionCharacteristicUUID = CBUUID.init(string: "99FA0021-338A-1024-8A49-009C0215F78A")
-    
+
     public static let deskControlServiceUUID = CBUUID.init(string: "99FA0001-338A-1024-8A49-009C0215F78A")
     public static let deskControlCharacteristicUUID = CBUUID.init(string: "99FA0002-338A-1024-8A49-009C0215F78A")
-    
+
     static let heightPositionOffset: Float = 61.5 // min
-    
-    
+
     let peripheral: CBPeripheral
-    
+
     var positionService: CBService?
     var positionCharacteristic: CBCharacteristic?
-        
+
     var controlService: CBService?
     var controlCharacteristic: CBCharacteristic?
-    
-    
+
     var speed: Float = 0
-    
+
     var hasLoadedPositionCharacteristicValues = false
-    
+
     var onPositionChange: (Float) -> Void = { _ in }
+
     var position: Float? {
         didSet {
-//            print("\(position)cm")
-            
+            // print("\(position)cm")
+
             if let position = position, hasLoadedPositionCharacteristicValues {
                 onPositionChange(position)
             }
-            
+
         }
     }
-    
+
+    var lastSwitchControlCommand: SwitchControlCommand? {
+        didSet {
+            if let oldValue,
+                let lastSwitchControlCommand,
+                oldValue.switchAction == .neutral,
+                lastSwitchControlCommand.time.timeIntervalSince(oldValue.time) <= 0.5 {
+                self.doubleTapDetected = true
+                print("DOUBLE TAP", lastSwitchControlCommand.switchAction)
+            } else {
+                self.doubleTapDetected = false
+            }
+        }
+    }
+
+    var doubleTapDetected = false
+
     init(peripheral: CBPeripheral) {
         self.peripheral = peripheral
-        
+
         super.init()
-        
+
         peripheral.delegate = self
         peripheral.discoverServices(nil)
     }
 }
 
 extension DeskPeripheral: CBPeripheralDelegate {
-    
-    
+
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        
+
         guard peripheral == self.peripheral, let services = peripheral.services else {
             return
         }
-        
+
         services.forEach { service in
             if service.uuid == DeskPeripheral.deskPositionServiceUUID {
                 positionService = service
@@ -73,58 +88,80 @@ extension DeskPeripheral: CBPeripheralDelegate {
             } else {
                 return
             }
-            
+
             peripheral.discoverCharacteristics(nil, for: service)
         }
     }
-    
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        
+
         guard peripheral == self.peripheral, let characteristics = service.characteristics else {
             return
         }
-        
+
         characteristics.forEach { characteristic in
             if characteristic.uuid == DeskPeripheral.deskPositionCharacteristicUUID {
                 // print("Discovered position characteristic: \(characteristic)")
                 positionCharacteristic = characteristic
-                
+
                 peripheral.readValue(for: characteristic)
                 // Start monitoring the position / speed
                 peripheral.setNotifyValue(true, for: characteristic)
             } else if characteristic.uuid == DeskPeripheral.deskControlCharacteristicUUID {
                 // print("Discovered control characteristic: \(characteristic)")
                 controlCharacteristic = characteristic
-            } else {
-                return
             }
-            
-            print(characteristic.properties)
+
+            // print(characteristic.properties)
         }
     }
-    
+
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        
+
         if characteristic == positionCharacteristic, let value = characteristic.value {
-            
+
             hasLoadedPositionCharacteristicValues = true
-            
+
             // Position = 16 Little Endian – Unsigned
             // Speed = 16 Little Endian – Signed
-            
+
             let positionValue = [value[0], value[1]].withUnsafeBytes {
                 $0.load(as: UInt16.self)
             }
-            
+
             let speedValue = [value[2], value[3]].withUnsafeBytes {
                 $0.load(as: Int16.self)
             }
-            
+
             speed = Float(speedValue)
             position = Float(positionValue) / 100 + DeskPeripheral.heightPositionOffset
 
+            var switchAction: SwitchControlCommand.SwitchAction = .neutral
+
+            switch speed {
+                case _ where speed == 0:
+                    switchAction = .neutral
+                case _ where speed < 0:
+                    switchAction = .down
+                case _ where speed > 0:
+                    switchAction = .up
+                default:
+                    break
+            }
+
+            let switchControlCommand = SwitchControlCommand(switchAction: switchAction, time: Date())
+            self.lastSwitchControlCommand = SwitchControlCommand(switchAction: switchAction, time: Date())
         }
-        
+    }
+}
+
+struct SwitchControlCommand {
+    enum SwitchAction {
+        case neutral
+        case up
+        case down
     }
 
+    let switchAction: SwitchAction
+    let time: Date
 }

--- a/Desk Controller/Preferences/Preferences.swift
+++ b/Desk Controller/Preferences/Preferences.swift
@@ -26,6 +26,8 @@ class Preferences {
     private let offsetKey = "positionOffsetValue"
     
     private let isMetricKey = "isMetric"
+
+    private let doubleTapToSitStandKey = "doubleTapToSitStandKey"
     
     private let hasLaunched = "hasLaunched"
 
@@ -137,6 +139,16 @@ class Preferences {
         set {
             // print("Saving launch at login: \(newValue)")
             LaunchAtLogin.isEnabled = newValue
+        }
+    }
+
+    var doubleTapToSitStand: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: doubleTapToSitStandKey)
+        }
+
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: doubleTapToSitStandKey)
         }
     }
     

--- a/Desk Controller/Preferences/PreferencesWindowController.swift
+++ b/Desk Controller/Preferences/PreferencesWindowController.swift
@@ -14,6 +14,8 @@ class PreferencesWindowController: NSWindowController {
     
     @IBOutlet weak var unitsPopUpButton: NSPopUpButton!
     @IBOutlet weak var currentHeightField: NSTextField?
+
+    @IBOutlet weak var doubleTapToSitStandCheckbox: NSButton!
     
     @IBOutlet weak var autoStandEnabledCheckbox: NSButton!
     @IBOutlet weak var autoStandIntervalStepper: NSStepper!
@@ -47,6 +49,7 @@ class PreferencesWindowController: NSWindowController {
         super.windowDidLoad()
         
         openAtLoginCheckbox.state = Preferences.shared.openAtLogin ? .on : .off
+        doubleTapToSitStandCheckbox.state = Preferences.shared.doubleTapToSitStand ? .on : .off
         
         unitsPopUpButton.selectItem(at: Preferences.shared.isMetric ? 0 : 1)
         
@@ -128,6 +131,10 @@ class PreferencesWindowController: NSWindowController {
             let offset = newPosition - deskPosition
             Preferences.shared.positionOffset = offset
         }
+    }
+
+    @IBAction func toggledDoubleTaptoSitStandCheckbox(_ sender: NSButton) {
+        Preferences.shared.doubleTapToSitStand = sender.state == .on
     }
     
     @IBAction func toggledAutoStandCheckbox(_ sender: NSButton) {

--- a/Desk Controller/Preferences/PreferencesWindowController.xib
+++ b/Desk Controller/Preferences/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,6 +14,7 @@
                 <outlet property="autoStandIntervalLabel" destination="NTv-2D-mHb" id="RYl-I0-LBa"/>
                 <outlet property="autoStandIntervalStepper" destination="ggi-1R-wj8" id="AUQ-FA-tgx"/>
                 <outlet property="currentHeightField" destination="dSd-Fl-ODs" id="oOZ-tl-A7C"/>
+                <outlet property="doubleTapToSitStandCheckbox" destination="OdD-Lq-f9R" id="yre-cC-0x8"/>
                 <outlet property="openAtLoginCheckbox" destination="gnX-fs-m9E" id="vUK-gn-HKD"/>
                 <outlet property="sittingHeightField" destination="gvS-lt-sfD" id="xq8-4Y-OYz"/>
                 <outlet property="standingHeightField" destination="QUY-8t-Wgs" id="AEV-gC-Ota"/>
@@ -26,14 +27,14 @@
         <window identifier="PreferencesControllerId" title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" rightStrut="YES" topStrut="YES"/>
-            <rect key="contentRect" x="2129" y="992" width="265" height="398"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
+            <rect key="contentRect" x="2129" y="992" width="265" height="491"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="265" height="398"/>
+                <rect key="frame" x="0.0" y="0.0" width="265" height="491"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sc5-lH-IW6">
-                        <rect key="frame" x="18" y="360" width="104" height="16"/>
+                        <rect key="frame" x="18" y="453" width="104" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Standing height:" id="Ic3-Mz-Mlw">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -42,7 +43,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QUY-8t-Wgs">
-                        <rect key="frame" x="145" y="357" width="100" height="21"/>
+                        <rect key="frame" x="145" y="450" width="100" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="mEN-r9-2Vs">
                             <font key="font" metaFont="system"/>
@@ -54,7 +55,7 @@
                         </connections>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bYa-Z2-T1W">
-                        <rect key="frame" x="18" y="329" width="104" height="16"/>
+                        <rect key="frame" x="18" y="422" width="104" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Sitting height:" id="ms6-Qo-GGH">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -63,7 +64,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-lt-sfD">
-                        <rect key="frame" x="145" y="326" width="100" height="21"/>
+                        <rect key="frame" x="145" y="419" width="100" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="vhr-dw-Fb0">
                             <font key="font" metaFont="system"/>
@@ -75,7 +76,7 @@
                         </connections>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C4o-dX-fBQ">
-                        <rect key="frame" x="38" y="125" width="103" height="16"/>
+                        <rect key="frame" x="38" y="118" width="103" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Activity timeout:" id="mp5-eb-NG2">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -84,7 +85,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XtZ-dx-Zv5">
-                        <rect key="frame" x="18" y="298" width="104" height="16"/>
+                        <rect key="frame" x="18" y="391" width="104" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Units:" id="hWq-YF-PhL">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -93,7 +94,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBS-N7-nAN">
-                        <rect key="frame" x="142" y="292" width="107" height="25"/>
+                        <rect key="frame" x="142" y="385" width="107" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" title="cm" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="v3V-zl-5WP" id="TJa-vC-6O8">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -110,7 +111,7 @@
                         </connections>
                     </popUpButton>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XZo-Vb-hHK">
-                        <rect key="frame" x="18" y="264" width="104" height="16"/>
+                        <rect key="frame" x="18" y="357" width="104" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Current height:" id="8ML-Vw-t7i">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -119,7 +120,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dSd-Fl-ODs">
-                        <rect key="frame" x="145" y="261" width="100" height="21"/>
+                        <rect key="frame" x="145" y="354" width="100" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="xL4-H6-un6">
                             <font key="font" metaFont="system"/>
@@ -131,7 +132,7 @@
                         </connections>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KM3-wE-FMs">
-                        <rect key="frame" x="18" y="205" width="229" height="39"/>
+                        <rect key="frame" x="18" y="298" width="229" height="39"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" title="To calibrate the correct height of the desk, measure the current distance from floor to the desktop and enter the value." id="dQi-9h-xvZ">
                             <font key="font" textStyle="footnote" name=".SFNS-Regular"/>
@@ -140,15 +141,15 @@
                         </textFieldCell>
                     </textField>
                     <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="stF-ff-gMM">
-                        <rect key="frame" x="20" y="50" width="225" height="5"/>
+                        <rect key="frame" x="20" y="43" width="225" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </box>
                     <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="80h-wD-iJo">
-                        <rect key="frame" x="20" y="186" width="225" height="5"/>
+                        <rect key="frame" x="20" y="179" width="225" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </box>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gnX-fs-m9E">
-                        <rect key="frame" x="18" y="19" width="205" height="18"/>
+                        <rect key="frame" x="18" y="12" width="205" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Open Desk Controller at login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Llu-P8-H6I">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -159,7 +160,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zid-bM-9JT">
-                        <rect key="frame" x="18" y="153" width="150" height="18"/>
+                        <rect key="frame" x="18" y="146" width="150" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Automatically stand:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iDo-G5-iCI">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -170,7 +171,7 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gXK-Qb-7OG">
-                        <rect key="frame" x="18" y="67" width="229" height="39"/>
+                        <rect key="frame" x="18" y="60" width="229" height="39"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" title="Automatically raise the desk the specified number of minutes per hour if the computer is active." id="1Ee-wo-6JK">
                             <font key="font" textStyle="footnote" name=".SFNS-Regular"/>
@@ -179,7 +180,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NTv-2D-mHb">
-                        <rect key="frame" x="194" y="148" width="32" height="22"/>
+                        <rect key="frame" x="194" y="141" width="32" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" state="on" alignment="right" title="59" id="E7E-c7-FaI">
                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="dd6-Ee-2gP"/>
@@ -189,7 +190,7 @@
                         </textFieldCell>
                     </textField>
                     <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ggi-1R-wj8">
-                        <rect key="frame" x="229" y="147" width="19" height="28"/>
+                        <rect key="frame" x="229" y="140" width="19" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <stepperCell key="cell" continuous="YES" alignment="left" increment="5" minValue="5" maxValue="55" doubleValue="10" id="92t-O6-c0r"/>
                         <connections>
@@ -197,7 +198,7 @@
                         </connections>
                     </stepper>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X6K-r1-L6E">
-                        <rect key="frame" x="194" y="119" width="32" height="22"/>
+                        <rect key="frame" x="194" y="112" width="32" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" state="on" alignment="right" title="59" id="dME-eH-SLK">
                             <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="d69-YI-d8s"/>
@@ -207,19 +208,44 @@
                         </textFieldCell>
                     </textField>
                     <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QVO-aT-Ri9">
-                        <rect key="frame" x="229" y="118" width="19" height="28"/>
+                        <rect key="frame" x="229" y="111" width="19" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <stepperCell key="cell" continuous="YES" alignment="left" increment="5" minValue="5" maxValue="60" doubleValue="10" id="At4-ul-AS4"/>
                         <connections>
                             <action selector="changedAutoStandInactiveStepper:" target="-2" id="jPd-ZJ-kBp"/>
                         </connections>
                     </stepper>
+                    <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="evb-f6-c63">
+                        <rect key="frame" x="20" y="282" width="225" height="5"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    </box>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OdD-Lq-f9R">
+                        <rect key="frame" x="18" y="252" width="234" height="22"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Double tap handle to sit and stand" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Ic4-OP-hfP">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggledDoubleTaptoSitStandCheckbox:" target="-2" id="RAs-Pr-Q0D"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T2o-I5-ND1">
+                        <rect key="frame" x="18" y="193" width="229" height="52"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" id="lYb-L6-yie">
+                            <font key="font" textStyle="footnote" name=".SFNS-Regular"/>
+                            <string key="title">Double tap on the desk control handle to automatically move to your sit and stand presets.  Double tap up to stand and down to sit.</string>
+                            <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="-231.5" y="276"/>
+            <point key="canvasLocation" x="-231.5" y="322.5"/>
         </window>
     </objects>
 </document>

--- a/Desk Controller/ViewController.swift
+++ b/Desk Controller/ViewController.swift
@@ -178,8 +178,6 @@ class ViewController: NSViewController {
                 return
             }
 
-            self?.controller?.stopMoving()
-
             DispatchQueue.main.async {
                 if direction == .up {
                     self?.stand()
@@ -265,6 +263,7 @@ class ViewController: NSViewController {
     }
 
     private func sit() {
+        controller?.stopMoving()
         controller?.moveToPosition(.sit)
     }
     
@@ -282,6 +281,7 @@ class ViewController: NSViewController {
     }
 
     private func stand() {
+        controller?.stopMoving()
         controller?.moveToPosition(.stand)
     }
     

--- a/Desk Controller/ViewController.swift
+++ b/Desk Controller/ViewController.swift
@@ -172,6 +172,24 @@ class ViewController: NSViewController {
                 }
             }
         }
+
+        controller?.onDoubleTapDetected = { [weak self] direction in
+            guard Preferences.shared.doubleTapToSitStand else {
+                return
+            }
+
+            self?.controller?.stopMoving()
+
+            DispatchQueue.main.async {
+                if direction == .up {
+                    self?.stand()
+                }
+
+                if direction == .down {
+                    self?.sit()
+                }
+            }
+        }
         
     }
     
@@ -234,11 +252,10 @@ class ViewController: NSViewController {
     }
     
     @IBAction func sit(_ sender: Any) {
-        
         guard let button = sitButton else {
             return
         }
-        
+
         if button.title == stopLabelString {
             controller?.stopMoving()
         } else {
@@ -246,19 +263,26 @@ class ViewController: NSViewController {
             controller?.moveToPosition(.sit)
         }
     }
+
+    private func sit() {
+        controller?.moveToPosition(.sit)
+    }
     
     @IBAction func stand(_ sender: Any) {
-        
         guard let button = standButton else {
             return
         }
-        
+
         if button.title == stopLabelString {
             controller?.stopMoving()
         } else {
             button.title = stopLabelString
             controller?.moveToPosition(.stand)
         }
+    }
+
+    private func stand() {
+        controller?.moveToPosition(.stand)
     }
     
     @IBAction func showPreferences(_ sender: Any) {


### PR DESCRIPTION
This PR adds the ability for users to move between sitting and standing by double tapping the hardware handle on the desk in the appropriate direction.  It also adds the appropriate preference checkbox to allow users to enable/disable it.